### PR TITLE
this fixes the keyerror problem

### DIFF
--- a/meetup-rsvper.py
+++ b/meetup-rsvper.py
@@ -194,15 +194,19 @@ def rsvp_for_group_events(group_id):
 
         my_rsvp = get_my_rsvp(event['id'])
         if not my_rsvp:
-            if event['yes_rsvp_count'] >= event['rsvp_limit']:
-                log('[%s] Cannot RSVP to %s, the event is full. Please visit '
-                    '%s to add yourself to the waiting list if one is '
-                    'available.' % (
-                    event['group']['name'], 
-                    event['name'], 
-                    event['event_url']
-                ))
-            elif rsvp_yes(event_id):
+            try:
+                # errors when event objets no longer include the key 'rsvp_limit'
+                if event['yes_rsvp_count'] >= event['rsvp_limit']:
+                    log('[%s] Cannot RSVP to %s, the event is full. Please visit '
+                        '%s to add yourself to the waiting list if one is '
+                        'available.' % (
+                        event['group']['name'], 
+                        event['name'], 
+                        event['event_url']
+                    ))
+            except KeyError:
+                return 0
+            if rsvp_yes(event_id):
                 log('[%s] RSVP\'d yes to "%s" (%s)' % (group_name, event_name,
                                                        event_url)
                 )


### PR DESCRIPTION
...of not being able to find the 'rsvp_limit' key for events that haven't been rsvp'ed for.

I tried to run the script after setup and it broke and did not run:

`[cchilders:~/projects/meetup-rsvper [master]$ ./meetup-rsvper.py 
Traceback (most recent call last):
  File "./meetup-rsvper.py", line 290, in <module>
    main()
  File "./meetup-rsvper.py", line 286, in main
    rsvp_for_groups()
  File "./meetup-rsvper.py", line 233, in rsvp_for_groups
    rsvp_for_group_events(group_id)
  File "./meetup-rsvper.py", line 197, in rsvp_for_group_events
    if event['yes_rsvp_count'] >= event['rsvp_limit']:
KeyError: 'rsvp_limit'](url)`

it is now fixed
